### PR TITLE
refactor: use find + exec, also allow dir via argv1

### DIFF
--- a/clearNodeModules.sh
+++ b/clearNodeModules.sh
@@ -1,16 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env sh
+set -e
 
-function delete_node_modules {
-  for file in "$1"/*; do
-    if [[ -d "$file" ]]; then
-      if [[ "$file" == *"/node_modules" ]]; then
-        echo "Deletando $file"
-        rm -rf "$file"
-      else
-        delete_node_modules "$file"
-      fi
-    fi
-  done
-}
-
-delete_node_modules "$(pwd)"
+find "${1-"$(pwd)"}" -name 'node_modules' -type d -prune -exec rm -rf '{}' +


### PR DESCRIPTION
Essa PR faz o script buscar **recursivamente** por qualquer `node_modules` no diretório atual ou o que for passado via argv1.
Também é interessante evitar usar `bash` em scripts, pois não é todo mundo que tem bash instalado.

```sh
# removing all node_modules inside ~/repos
./clearNodeModules.sh ~/repos
```

o set -e garante que se o script falhar ele feche imediatamente